### PR TITLE
Add a language server settings page

### DIFF
--- a/src/main/java/io/ballerina/plugins/idea/configuration/ui/BallerinaLSPanel.java
+++ b/src/main/java/io/ballerina/plugins/idea/configuration/ui/BallerinaLSPanel.java
@@ -56,10 +56,10 @@ public class BallerinaLSPanel implements BallerinaSettingsPanel {
         panel.add(BallerinaSettingsPanelTitle.getTitleComponent("Language server settings"), gbc);
         gbc.gridy++;
 
-        panel.add(traceLogsCheckBox, gbc);
+        panel.add(debugLogsCheckBox, gbc);
         gbc.gridy++;
 
-        panel.add(debugLogsCheckBox, gbc);
+        panel.add(traceLogsCheckBox, gbc);
         gbc.gridy++;
 
         return panel;

--- a/src/main/java/io/ballerina/plugins/idea/configuration/ui/BallerinaLSPanel.java
+++ b/src/main/java/io/ballerina/plugins/idea/configuration/ui/BallerinaLSPanel.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.ballerina.plugins.idea.configuration.ui;
+
+import com.intellij.util.ui.JBUI;
+import io.ballerina.plugins.idea.preloading.BallerinaLSConfigSettings;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+/**
+ * Ballerina language server related settings panel.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaLSPanel implements BallerinaSettingsPanel {
+
+    private JCheckBox traceLogsCheckBox = new JCheckBox("Enable language server trace logs");
+    private JCheckBox debugLogsCheckBox = new JCheckBox("Enable language server debug logs");
+    private final JPanel panel = new JPanel(new GridBagLayout());
+
+    public BallerinaLSPanel() {
+        init();
+    }
+
+    @Override
+    public JComponent getPanel() {
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.weightx = 1.0;
+        gbc.weighty = 0;
+        gbc.insets = JBUI.insets(2, 0);
+
+        panel.add(BallerinaSettingsPanelTitle.getTitleComponent("Language server settings"), gbc);
+        gbc.gridy++;
+
+        panel.add(traceLogsCheckBox, gbc);
+        gbc.gridy++;
+
+        panel.add(debugLogsCheckBox, gbc);
+        gbc.gridy++;
+
+        return panel;
+    }
+
+    @Override
+    public void disposeUi() {
+        traceLogsCheckBox = null;
+        debugLogsCheckBox = null;
+        panel.removeAll();
+    }
+
+    private void init() {
+        traceLogsCheckBox.setSelected(BallerinaLSConfigSettings.getInstance().isTraceLog());
+        debugLogsCheckBox.setSelected(BallerinaLSConfigSettings.getInstance().isDebugLog());
+    }
+
+    public boolean isTraceLogsEnabled() {
+        return traceLogsCheckBox.isSelected();
+    }
+
+    public boolean isDebugLogsEnabled() {
+        return debugLogsCheckBox.isSelected();
+    }
+}

--- a/src/main/java/io/ballerina/plugins/idea/extensions/BallerinaExtendedLanguageClient.java
+++ b/src/main/java/io/ballerina/plugins/idea/extensions/BallerinaExtendedLanguageClient.java
@@ -17,11 +17,10 @@
 
 package io.ballerina.plugins.idea.extensions;
 
-import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
 import io.ballerina.plugins.idea.preloading.BallerinaLSConfigSettings;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.MessageParams;
@@ -51,10 +50,12 @@ public class BallerinaExtendedLanguageClient extends DefaultLanguageClient {
 
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private boolean statusTriggered = false;
+    private final Project project;
 
     public BallerinaExtendedLanguageClient(@NotNull ClientContext context) {
         super(context);
         startStatusListener();
+        this.project = context.getProject();
     }
 
     private void startStatusListener() {
@@ -104,7 +105,6 @@ public class BallerinaExtendedLanguageClient extends DefaultLanguageClient {
         urlMatcher.appendTail(sb);
         message = sb.toString();
 
-        Notification notification = notificationGroup.createNotification(title, message, notificationType, null);
-        Notifications.Bus.notify(notification);
+        notificationGroup.createNotification(message, notificationType).setTitle(title).notify(project);
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds a language settings page component for Ballerina language server related settings. currently it has enabling language server trace logs and debug logs feature. Related to https://github.com/ballerina-platform/plugin-intellij/issues/51

## Approach
After enabling the features and applying them, there is no need to restart. The request to enable the features will be sent immediately to the language server. Additionally, the selected features will persist, so the next time the IDE starts up, the request to enable the features is sent to the language server right after initialization, allowing the features to be used at startup. Trace log and debug log notifications are sent to the IDE event log, so user can open the event log tab and view the notifications. These notifications are not popup type notifications so it will not disturb the user experience.

## Samples

*Settings page component*
![image](https://github.com/ballerina-platform/plugin-intellij/assets/110608712/5ab6dcb9-4390-456b-8d4c-a0cd741763d1)

*Notifications*
![image](https://github.com/ballerina-platform/plugin-intellij/assets/110608712/db002753-2c9f-4c23-9025-64d02f22c16e)
