### PR TITLE
Remove untilBuild property from plugin.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ tasks.withType(JavaCompile) {
 
 patchPluginXml {
     sinceBuild = project.sinceBuild
-    untilBuild = project.untilBuild
 }
 
 signPlugin {


### PR DESCRIPTION
## Purpose
This removes the `untilBuild` property from the plugin, allowing the plugin to work with all future IDEA versions.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Added/updated necessary documentation
- [ ] Checked Tooling Support
- [ ] Added necessary tests
   - [ ] Unit Tests
   - [ ] Integration Tests
- [ ] Increased Test Coverage

